### PR TITLE
Escape single colon in names

### DIFF
--- a/HexRaysPyTools/core/common.py
+++ b/HexRaysPyTools/core/common.py
@@ -1,7 +1,7 @@
 import re
 
 
-BAD_C_NAME_PATTERN = re.compile('[^a-zA-Z_0-9:]')
+BAD_C_NAME_PATTERN = re.compile(":::+|(?=:(?=[^:]))(?=(?<=[^:]):):|^:[^:]|[^:]:$|^:$|[^a-zA-Z_0-9:]")
 
 
 def demangled_name_to_c_str(name):


### PR DESCRIPTION
Some IDA generated names are of the form `[thunk]:funcname`, but the and thus the generated name will be `thunk_:funcname` which is an illegal declaration name.

Change the bad c name matching regex to match a single colon (that is, a one which is not a part of a pair). Also replace any occurrence of three or more consecutive colons, as this is also an invalid cpp name.