### PR TITLE
Fix Qt6-related import issues in IDA 9.2

### DIFF
--- a/HexRaysPyTools/core/classes.py
+++ b/HexRaysPyTools/core/classes.py
@@ -1,4 +1,9 @@
-from PyQt5 import QtCore, QtGui
+try:
+    from PySide6 import QtCore, QtGui # IDA 9.2+
+    from PySide6.QtCore import Signal as qtSignal
+except ImportError:
+    from PyQt5 import QtCore, QtGui
+    from PyQt5.QtCore import pyqtSignal as qtSignal
 
 import idaapi
 
@@ -435,7 +440,7 @@ class TreeItem(object):
 class TreeModel(QtCore.QAbstractItemModel):
     # TODO: Add higlighting if eip in function, consider setting breakpoints
 
-    refreshed = QtCore.pyqtSignal()
+    refreshed = qtSignal()
 
     def __init__(self, parent=None):
         super(TreeModel, self).__init__(parent)

--- a/HexRaysPyTools/core/temporary_structure.py
+++ b/HexRaysPyTools/core/temporary_structure.py
@@ -1,6 +1,9 @@
 import bisect
 import itertools
-from PyQt5 import QtCore, QtGui, QtWidgets
+try:
+    from PySide6 import QtCore, QtWidgets, QtGui # IDA 9.2+
+except ImportError:
+    from PyQt5 import QtCore, QtWidgets, QtGui
 from functools import reduce
 
 import ida_name

--- a/HexRaysPyTools/forms.py
+++ b/HexRaysPyTools/forms.py
@@ -1,6 +1,9 @@
 import os
 
-from PyQt5 import QtCore, QtWidgets, QtGui
+try:
+    from PySide6 import QtCore, QtWidgets, QtGui # IDA 9.2+
+except ImportError:
+    from PyQt5 import QtCore, QtWidgets, QtGui
 
 import idaapi
 import ida_kernwin


### PR DESCRIPTION
This PR fixes the most obvious instant load-time errors I ran into when using the plugin with the current IDA 9.2 beta. All were related to the switch to Qt6 in 9.2.

Note: I haven't done any real testing beyond fixing Qt loading in 9.2 and ensuring the plugin still works in 9.1. But the few things I tried in 9.2 seem to work fine after this change.